### PR TITLE
feat(DecryptionPage): add ButtonTopPage component for smooth scrollin…

### DIFF
--- a/src/components/decryption/DecryptionPage.jsx
+++ b/src/components/decryption/DecryptionPage.jsx
@@ -5,12 +5,13 @@ import TechnicalOperation from "./TechnicalOperation.jsx";
 import PracticalExample from "./PracticalExample.jsx";
 import LimitsAndBias from "./LimitsAndBias.jsx";
 import EducationalApplication from "./EducationalApplication.jsx";
+import ButtonTopPage from "../shared/ButtonTopPage.jsx";
 
 const DecryptionPage = () => {
     usePageTitle("Decryption");
 
     return (
-        <div>
+        <div id="top-page">
             <Navbar />
             <div className="max-w-7xl mx-auto px-4 py-8 text-center">
                 <h1>🔍 Décryptage technique et pédagogique de Website Carbon Calculator </h1>
@@ -48,6 +49,7 @@ const DecryptionPage = () => {
                     </div>
                 </div>
             </div>
+            <ButtonTopPage id={"top-page"} />
         </div>
     );
 }

--- a/src/components/shared/ButtonTopPage.jsx
+++ b/src/components/shared/ButtonTopPage.jsx
@@ -1,0 +1,16 @@
+const ButtonTopPage = () => {
+    function onClickScrollTop() {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+
+    return (
+        <div>
+            <button className="fixed bottom-4 right-4 bg-green-600 text-white px-4 py-2 rounded-full shadow-lg hover:bg-green-700 transition"
+            onClick={onClickScrollTop}>
+                🔝 Retour en haut de la page
+            </button>
+        </div>
+    )
+}
+
+export default ButtonTopPage;

--- a/src/components/toolsComparaison/ToolsComparaisonPage.jsx
+++ b/src/components/toolsComparaison/ToolsComparaisonPage.jsx
@@ -6,6 +6,7 @@ import toolsReportData from "../../data/toolsComparaison/toolsReport.json";
 import ToolsReport from "./ToolsReport.jsx";
 import Navbar from "../shared/Navbar.jsx";
 import usePageTitle from "../../hooks/usePageTitle.js";
+import ButtonTopPage from "../shared/ButtonTopPage.jsx";
 
 const ToolsComparaisonPage = () => {
     usePageTitle("Comparaison des Outils");
@@ -87,6 +88,7 @@ const ToolsComparaisonPage = () => {
                     </div>
                 )}
             </div>
+            <ButtonTopPage />
         </div>
     );
 };


### PR DESCRIPTION
This pull request introduces a new reusable "Back to Top" button component and integrates it into two main pages to improve user navigation. The button allows users to smoothly scroll back to the top of the page, enhancing the overall user experience.

**New UI Component:**

* Added a new `ButtonTopPage` component in `src/components/shared/ButtonTopPage.jsx`, which displays a floating button at the bottom-right corner for scrolling to the top of the page.

**Integration into Main Pages:**

* Imported and rendered `ButtonTopPage` in `DecryptionPage.jsx`, placing it at the bottom of the page content and setting the scroll target to the top of the page. [[1]](diffhunk://#diff-35318239d4091c340e59adbe469a62ab882c63ff7fce75cb8e61c23ea069e2e0R8-R14) [[2]](diffhunk://#diff-35318239d4091c340e59adbe469a62ab882c63ff7fce75cb8e61c23ea069e2e0R52)
* Imported and rendered `ButtonTopPage` in `ToolsComparaisonPage.jsx`, making the button available for users on the tools comparison page. [[1]](diffhunk://#diff-a6084b7c29cbf4759bd1e4c0600a6be375a310d3cd27d90b7541f67196fb61beR9) [[2]](diffhunk://#diff-a6084b7c29cbf4759bd1e4c0600a6be375a310d3cd27d90b7541f67196fb61beR91)